### PR TITLE
Remove Modal and Fragment from the Sidekick Library

### DIFF
--- a/tools/sidekick/library.json
+++ b/tools/sidekick/library.json
@@ -1,7 +1,7 @@
 {
-  "total": 12,
+  "total": 11,
   "offset": 0,
-  "limit": 12,
+  "limit": 11,
   "data": [
     {
       "name": "Table",
@@ -38,10 +38,6 @@
     {
       "name": "Tabs",
       "path": "/block-collection/tabs"
-    },
-    {
-      "name": "Fragment",
-      "path": "/block-collection/fragment"
     },
     {
       "name": "Search",

--- a/tools/sidekick/library.json
+++ b/tools/sidekick/library.json
@@ -1,7 +1,7 @@
 {
-  "total": 13,
+  "total": 12,
   "offset": 0,
-  "limit": 13,
+  "limit": 12,
   "data": [
     {
       "name": "Table",
@@ -30,10 +30,6 @@
     {
       "name": "Quote",
       "path": "/block-collection/quote"
-    },
-    {
-      "name": "Modal",
-      "path": "/block-collection/modal"
     },
     {
       "name": "Carousel",


### PR DESCRIPTION
Removes `Modal` and `Fragment` as they cannot be accurately mapped to, given the current approach.