### PR TITLE
Force boilerplate users to set their own mountpoint url in fstab.yaml

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://adobe.sharepoint.com/:f:/r/sites/AEMDemos/Shared%20Documents/sites/esaas-demos/sta-boilerplate?csf=1&web=1&e=cb3DgP
+  /: <sharepoint folder url>


### PR DESCRIPTION
This will prevent the catalyze flow from automatically updating files to the wrong folder.