### PR TITLE
Revert "Force boilerplate users to set their own mountpoint url in fstab.yaml"

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: <sharepoint folder url>
+  /: https://adobe.sharepoint.com/:f:/r/sites/AEMDemos/Shared%20Documents/sites/esaas-demos/sta-boilerplate?csf=1&web=1&e=cb3DgP


### PR DESCRIPTION
Reverts aemdemos/sta-boilerplate#18

This possibly breaks the mapping and importscript generation, we should look for a different approach.