### PR TITLE
fix: embed blocks have no filter

### DIFF
--- a/blocks/embed/_embed.json
+++ b/blocks/embed/_embed.json
@@ -9,8 +9,7 @@
             "resourceType": "core/franklin/components/block/v1/block",
             "template": {
               "name": "Embed",
-              "model": "embed",
-              "filter": "embed"
+              "model": "embed"
             }
           }
         }


### PR DESCRIPTION
https://github.com/adobe-rnd/aem-block-collection-xwalk/pull/14
